### PR TITLE
Fix CLS by adding width and height to unsized images in rapidreels

### DIFF
--- a/examples/rapidreels/components/ContentDropdown.tsx
+++ b/examples/rapidreels/components/ContentDropdown.tsx
@@ -25,6 +25,8 @@ function ContentDropdown({ config, setConfig }: ConfigProps) {
             <img
               src={content.image}
               alt={content.name}
+              width={150}
+              height={267}
               className="w-full h-32 object-cover rounded"
             />
             <span className="absolute bottom-2 left-2 text-white bg-black bg-opacity-50 px-2 py-1 rounded">

--- a/examples/rapidreels/components/PlatformSelection.tsx
+++ b/examples/rapidreels/components/PlatformSelection.tsx
@@ -24,6 +24,8 @@ function PlatformSelection({ config, setConfig }: ConfigProps) {
             <img
               src={platform.image}
               alt={platform.name}
+              width={150}
+              height={150}
               className="w-full h-32 object-contain rounded"
             />
             <span className="absolute bottom-2 left-2 text-white bg-black bg-opacity-50 px-2 py-1 rounded">


### PR DESCRIPTION
Fix CLS caused by unsized images in rapidreels
                                                                                                                                                                                                                                                                        Added explicit width and height attributes to <img> tags in PlatformSelection.tsx and ContentDropdown.tsx. 