### PR TITLE
fix(rapidreels,reelestate): inline body reset to eliminate CLS

### DIFF
--- a/examples/rapidreels/pages/_document.tsx
+++ b/examples/rapidreels/pages/_document.tsx
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <style dangerouslySetInnerHTML={{ __html: `body{margin:0}` }} />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/examples/reelestate/pages/_document.tsx
+++ b/examples/reelestate/pages/_document.tsx
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <style dangerouslySetInnerHTML={{ __html: `body{margin:0}` }} />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
Next.js Pages Router emits both <link rel="preload"> and <link rel="stylesheet"> for every globally-imported CSS file. The stylesheet loads from browser cache in ~0ms, but the preload fires a separate network request (~101ms later). When that copy resolves, Tailwind preflight's body{margin:0} is applied and the body snaps from browser-default margin:8px to margin:0 — a shift scored 0.616 in the iframe, reported as CLS 0.20 on shotstack.io/demos/social-media-video-maker/ and CLS on shotstack.io/demos/real-estate-video-listing-maker/.

Inlining body{margin:0} in _document.tsx means the body starts at margin:0 on first render, so the later Tailwind application produces no visual change and no shift is recorded.