### PR TITLE
fix(rapidreels,reelestate): extend inline reset to anchor body height pre-CSS

### DIFF
--- a/examples/rapidreels/pages/_document.tsx
+++ b/examples/rapidreels/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <style dangerouslySetInnerHTML={{ __html: `body{margin:0}` }} />
+        <style dangerouslySetInnerHTML={{ __html: `html,body{margin:0;height:100%}` }} />
       </Head>
       <body>
         <Main />

--- a/examples/reelestate/pages/_document.tsx
+++ b/examples/reelestate/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <style dangerouslySetInnerHTML={{ __html: `body{margin:0}` }} />
+        <style dangerouslySetInnerHTML={{ __html: `html,body{margin:0;height:100%}` }} />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
Adds html,body{height:100%} to the existing body{margin:0} inline reset so the body is always viewport height before the Tailwind stylesheet parses. Without this, h-screen only applies after the external CSS loads, causing the body to jump from content-height to 100vh — the remaining 0.20 CLS on the social-media-video-maker embed.